### PR TITLE
Set homebrew.cleanup to zap

### DIFF
--- a/darwin-configuration.nix
+++ b/darwin-configuration.nix
@@ -63,6 +63,7 @@
 
   homebrew = {
     autoUpdate = false;
+    cleanup = "zap";
     enable = true;
     global = {
       brewfile = true;


### PR DESCRIPTION
Closes #3

From the [doc](https://github.com/LnL7/nix-darwin/blob/bcdb6022b3a300abf59cb5d0106c158940f5120e/modules/homebrew.nix#L63):
When set to "zap", nix-darwin invokes brew bundle [install] with the --cleanup --zap flags. This uninstalls all formulas not listed in the generated Brewfile, and if the formula is a cask, removes all files associated with that cask. In other words, brew uninstall --zap is run for all those formulas.