### PR TITLE
Set user uid to 501

### DIFF
--- a/darwin-configuration.nix
+++ b/darwin-configuration.nix
@@ -11,7 +11,7 @@
     users.francis = {
       createHome = true;
       home = "/Users/francis";
-      uid = 1000;
+      uid = 501;
     };
   };
 


### PR DESCRIPTION
It is already set to 501 on my current install so darwin-
rebuild was complaining.