### PR TITLE
Fix random stuff

### DIFF
--- a/darwin-configuration.nix
+++ b/darwin-configuration.nix
@@ -131,7 +131,7 @@
             plugins = [ "sudo" ];
           };
           shellAliases = {
-            "cat" = "bat";
+            "cat" = "${pkgs.bat}/bin/bat";
             ".." = "cd ..";
           };
         };


### PR DESCRIPTION
- Remove .hushlogin file (was useful when I was using the default terminal app).
- Use bat's absolute path in zsh shell aliases.