### PR TITLE
Setup 1password identity agent for ssh

### DIFF
--- a/home-manager.nix
+++ b/home-manager.nix
@@ -87,6 +87,13 @@
       enableAliases = true;
     };
 
+    ssh = {
+      enable = true;
+      extraConfig = ''
+        IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+      '';
+    };
+
     starship.enable = true;
 
     tmux.enable = true;


### PR DESCRIPTION
This PR sets up 1password as the identity agent. That way, we don't have keep sensitive information like the private key on the host. It's securely stored in the 1password vault.

Used this [documentation](https://developer.1password.com/docs/ssh/get-started/#step-4-configure-your-ssh-or-git-client).