### PR TITLE
Undo gh op setup

### DIFF
--- a/home-manager.nix
+++ b/home-manager.nix
@@ -140,12 +140,7 @@
       shellAliases = {
         "cat" = "${pkgs.bat}/bin/bat";
         ".." = "cd ..";
-        "gh" = "op run --env-file=${config.xdg.configHome}/op/gh.env -- gh";
       };
     };
   };
-
-  xdg.configFile."op/gh.env".text = ''
-    GH_TOKEN=op://Private/GitHub/Credentials/gh_pat
-  '';
 }


### PR DESCRIPTION
Using `op` to use `GH_TOKEN` to authenticate `gh` commands is not needed anymore. I was able to authenticate using `gh auth login`. There was a problem with `op run` not being able to let `gh` run interactively.
