### PR TITLE
Add bindkey -e in .zshrc

### DIFF
--- a/home-manager.nix
+++ b/home-manager.nix
@@ -130,8 +130,7 @@
       dotDir = ".config/zsh";
       enable = true;
       initExtra = ''
-        bindkey '^[[1;3C' emacs-forward-word
-        bindkey '^[[1;3D' emacs-backward-word
+        bindkey -e  # set emacs bindkeys
         eval "$(op completion zsh)"; compdef _op op
         eval "$(gh completion -s zsh)"; compdef _gh gh
       '';


### PR DESCRIPTION
This command sets all emacs keybinds in the shell.