### PR TITLE
Use SSH_AUTH_SOCK instead of IdentityAgent config

### DIFF
--- a/home-manager.nix
+++ b/home-manager.nix
@@ -114,12 +114,7 @@
       enableAliases = true;
     };
 
-    ssh = {
-      enable = true;
-      extraConfig = ''
-        IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
-      '';
-    };
+    ssh.enable = true;
 
     starship.enable = true;
 
@@ -170,6 +165,9 @@
       oh-my-zsh = {
         enable = true;
         plugins = [ "sudo" ];
+      };
+      sessionVariables = {
+        SSH_AUTH_SOCK = "~/Library/Group\ Containers/2BUA8C4S2C.com.1password/t/agent.sock";
       };
       shellAliases = {
         "cat" = "${pkgs.bat}/bin/bat";


### PR DESCRIPTION
By using this env variable, we can use `ssh-add -l` to list SSH keys that are available from 1Password.