### PR TITLE
Use wezterm instead of alacritty

### DIFF
--- a/home-manager/flake-module.nix
+++ b/home-manager/flake-module.nix
@@ -17,6 +17,7 @@
           ./modules/stylix.nix
           ./modules/terminal.nix
           ./modules/vscode.nix
+          ./modules/wezterm.nix
           ./modules/zellij.nix
         ];
         home.stateVersion = "22.11";

--- a/home-manager/modules/alacritty.nix
+++ b/home-manager/modules/alacritty.nix
@@ -2,7 +2,7 @@
 
 {
   programs.alacritty = {
-    enable = true;
+    enable = false;
     settings = {
       window = {
         dynamic_title = false;

--- a/home-manager/modules/wezterm.nix
+++ b/home-manager/modules/wezterm.nix
@@ -1,0 +1,9 @@
+{ ... }:
+
+{
+  programs.wezterm = {
+    enable = true;
+    enableZshIntegration = true;
+    extraConfig = builtins.readFile ./wezterm/wezterm.lua;
+  };
+}

--- a/home-manager/modules/wezterm/wezterm.lua
+++ b/home-manager/modules/wezterm/wezterm.lua
@@ -1,0 +1,14 @@
+local wezterm = require 'wezterm'
+local config = wezterm.config_builder()
+
+wezterm.on("gui-startup", function()
+  local tab, pane, window = wezterm.mux.spawn_window {}
+  window:gui_window():maximize()
+end)
+
+config.enable_tab_bar = false
+config.front_end = 'WebGpu'
+config.window_close_confirmation = 'NeverPrompt'
+config.window_decorations = 'RESIZE'
+
+return config


### PR DESCRIPTION
The main reason why I'm switching is because wezterm supports rendering images in the terminal which is pretty useful for yazi.

I disabled alacritty but kept the module since I might want to start using it again in the future.