### PR TITLE
299 setup yazi

### DIFF
--- a/home-manager/flake-module.nix
+++ b/home-manager/flake-module.nix
@@ -18,6 +18,7 @@
           ./modules/terminal.nix
           ./modules/vscode.nix
           ./modules/wezterm.nix
+          ./modules/yazi.nix
           ./modules/zellij.nix
         ];
         home.stateVersion = "22.11";

--- a/home-manager/modules/helix.nix
+++ b/home-manager/modules/helix.nix
@@ -1,5 +1,20 @@
-{ pkgs, ... }:
+{ config, lib, pkgs, ... }:
 
+let
+  yaziPicker = pkgs.writeShellScriptBin "yazi-picker" ''
+    paths=$(${pkgs.yazi}/bin/yazi --chooser-file=/dev/stdout | while read -r; do printf "%q " "$REPLY"; done)
+
+    if [[ -n "$paths" ]]; then
+    	${pkgs.zellij}/bin/zellij action toggle-floating-panes
+    	${pkgs.zellij}/bin/zellij action write 27 # send <Escape> key
+    	${pkgs.zellij}/bin/zellij action write-chars ":open $paths"
+    	${pkgs.zellij}/bin/zellij action write 13 # send <Enter> key
+    	${pkgs.zellij}/bin/zellij action toggle-floating-panes
+    fi
+
+    ${pkgs.zellij}/bin/zellij action close-pane
+  '';
+in
 {
   programs.helix = {
     enable = true;
@@ -14,6 +29,9 @@
     };
     settings = {
       editor.line-number = "relative";
+      keys.normal = {
+        "C-y" = lib.mkIf config.programs.yazi.enable ":sh ${pkgs.zellij}/bin/zellij run -f -n yazi-picker -x 10% -y 10% --width 80% --height 80% -- ${yaziPicker}/bin/yazi-picker";
+      };
     };
   };
 }

--- a/home-manager/modules/yazi.nix
+++ b/home-manager/modules/yazi.nix
@@ -1,0 +1,8 @@
+{ ... }:
+
+{
+  programs.yazi = {
+    enable = true;
+    enableZshIntegration = true;
+  };
+}


### PR DESCRIPTION
Closes #299

- Enable yazi
  - Uses the wrapped version that wraps dependencies like `fd`, `jq` and `ripgrep`
- Setup file-picker for helix that uses yazi